### PR TITLE
Bump version to 0.2.0.

### DIFF
--- a/zlib.nimble
+++ b/zlib.nimble
@@ -10,7 +10,7 @@
 mode = ScriptMode.Verbose
 
 packageName   = "zlib"
-version       = "0.1.0"
+version       = "0.2.0"
 author        = "Status Research & Development GmbH"
 description   = "zlib wrapper in nim"
 license       = "Apache License 2.0"


### PR DESCRIPTION
Because zlib doesn't use versions, Nimble dependency resolver would omit updating it and keep the older version locked. This leads to compilation errors if stew isn't installed because there's import stew/results in the older version and import results in the newer one.